### PR TITLE
add dockerfile for ease of use

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y software-properties-common && \
+  add-apt-repository -y ppa:ubuntu-toolchain-r/test
+
+RUN apt-get update && \
+  apt-get install -y nano git curl nodejs npm \
+  libstdc++-4.9-dev
+
+RUN npm install -g n
+
+RUN n 5.7.0 && ln -fs `n bin 5.7.0` /usr/bin/node
+
+# Install nodegit
+RUN git clone https://github.com/nodegit/nodegit && \
+  cd nodegit && \
+  git checkout v0.11.4
+
+# Some hacking to get nodegit to install
+# See: https://github.com/nodegit/nodegit/issues/650
+RUN cd /nodegit && \
+  npm install && \
+  cd vendor/libssh2 && \
+  ./configure && \
+  cd ../.. && \
+  npm run rebuild && \
+  npm link
+
+# install nodegit-kit
+RUN git clone https://github.com/yofreke/nodegit-kit
+
+RUN cd /nodegit-kit && \
+  npm link nodegit && \
+  npm install

--- a/docker/build-container.sh
+++ b/docker/build-container.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker build \
+  -t nodegit-kit:latest \
+  .

--- a/docker/run-container.sh
+++ b/docker/run-container.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Execute as `./run-container dev` to mount the nodegit-kit directory in to the container
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NODEGIT_KIT_DIR=`dirname $DIR`
+
+EXTRA_OPTS=""
+if [ "$1" == "dev" ]; then
+  EXTRA_OPTS="-v $NODEGIT_KIT_DIR:/nodegit-kit"
+fi
+
+docker run\
+  -it \
+  $EXTRA_OPTS \
+  nodegit-kit:latest \
+  /bin/bash

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commander": "^2.9.0",
     "debug": "^2.2.0",
     "fildes": "^1.0.5",
-    "nodegit": "*"
+    "nodegit": "=0.11.4"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
how to use:
- `./build-container.sh`
- `./run-container.sh`

also can do `./run-container.sh dev` if you want to mount the parent directory in to the container for ease of use.
